### PR TITLE
Update event date and title for MenderCon to 2025 in hero section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,11 +51,9 @@ navigationLinks:
 
 # Hero Block
 heroImage: "hero.jpg"
-heroTitle: "MenderCon 2024"
-eventDate: "May 16, 2024"
+eventDate: "May 15, 2025"
 heroButtons:
  - {permalink: "#about", text: "Learn more"}
- - {link: "https://www.eventbrite.com/e/mendercon-2024-registration-872814500667", text: "Get tickets"}
 
 # About Block
 aboutTitle: "About MenderCon"

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -4,8 +4,8 @@
     <div class="content-wrapper">
     <div class="jumbotron">
         <div class="title animated hiding" data-animation="fadeInDown" data-delay="500">
-            <h1>Mender<span class="title-highlight">Con</span> 2024</h1>
-            <p class="title-date">{{ site.eventDate }}</p>
+            <h1>Mender<span class="title-highlight">Con</span> 2025</h1>
+            <p class="title-date">{{ site.eventDate }} (tickets on sale soon-ish)</p>
             {% for button in site.heroButtons %}
             <a href="{% if button.permalink != null %} {{ button.permalink | prepend: site.baseurl }} {% else %} {{ button.link }} {% endif %}" class="btn btn-primary waves-effect waves-button waves-light waves-float" {% if button.link != null %}target="_blank"{% endif %}>{{ button.text }}</a>
             {% endfor %}


### PR DESCRIPTION
Updated the date on the main page for the MenderCon 2025 dates.  Also removed the buy tickets button for now and put a message saying tickets will be on sale soon.

Small PR to make sure I understand how the website works and make sure the build and deploy process still works.