### PR TITLE
Add ticket link and update event date display for MenderCon 2025

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -55,6 +55,7 @@ eventDate: "May 15, 2025"
 heroButtons:
  - {permalink: "#about", text: "Learn more"}
  - {link: "https://www.papercall.io/mendercon-2025", text: "Apply to our CFP"}
+ - {link: "https://www.eventbrite.com/e/mendercon-2025-tickets-1270907050199", text: "Get tickets"}
 
 # About Block
 aboutTitle: "About MenderCon"

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -5,7 +5,7 @@
     <div class="jumbotron">
         <div class="title animated hiding" data-animation="fadeInDown" data-delay="500">
             <h1>Mender<span class="title-highlight">Con</span> 2025</h1>
-            <p class="title-date">{{ site.eventDate }} (tickets on sale soon-ish)</p>
+            <p class="title-date">{{ site.eventDate }}</p>
             {% for button in site.heroButtons %}
             <a href="{% if button.permalink != null %} {{ button.permalink | prepend: site.baseurl }} {% else %} {{ button.link }} {% endif %}" class="btn btn-primary waves-effect waves-button waves-light waves-float" {% if button.link != null %}target="_blank"{% endif %}>{{ button.text }}</a>
             {% endfor %}


### PR DESCRIPTION
Added a button to buy the tickets and removed the "soon-ish" text.  Fixes #57.

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/29ba5d5b-68aa-4a8c-a359-97f79feb3a7f" />
