### PR TITLE
Remove sponsor PureType

### DIFF
--- a/_data/partners.yml
+++ b/_data/partners.yml
@@ -2,6 +2,4 @@
   group: "General sponsor"
   elements:
       - {name: "Corgibytes", description: "Corgibytes - old code; new tricks", link: "https://corgibytes.com", imageUrl: "corgibytes-logo.png"}
-      # - {name: "Planet Argon", description: "Planet Argon: Software Development with Ruby on Rails", link: "https://planetargon.com", imageUrl: "planet-argon-logo.png"}
-      - {name: "PureType", description: "Personalized microlearning platform for ambitious engineering teams", link: "https://puretype.ai/", imageUrl: "pure-type-logo.png"}
 


### PR DESCRIPTION
Remove sponsor PureType.  Fixes #59.

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/e84ba24f-8abc-4e29-970d-45e827ee3cb3" />
