### PR TITLE
Fix mastodon partial

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -101,6 +101,7 @@ tootsFeedImage: "mastodon-feed.jpg"
 tootsFeedTitle: "What's Up?"
 mastodonHashTag: "MenderCon2025"
 mastodonFeedApiUrl: "https://toot.legacycode.rocks/api/v1/timelines/tag/MenderCon2025"
+mastodonFeedUrl: "https://toot.legacycode.rocks/tags/MenderCon2025"
 
 # Partners Block
 organizersTitle: "Organizers"

--- a/_config.yml
+++ b/_config.yml
@@ -28,8 +28,6 @@ collections:
 
 # Head
 metaKeywords: "mendercon, menders, unconference, refactoring, development, programming, legacy, code, software, remodeling, technical, debt"
-mastodonServer: "https://toot.legacycode.rocks"
-mastodonAccount: "@mendercon"
 socialImageSrcGooglePlus: "/img/seo/sharing-google-plus.png"
 socialImageSrcMastodon: "/img/seo/sharing-mastodon.png"
 socialImageSrcFacebook: "/img/seo/sharing-facebook.png"
@@ -100,8 +98,12 @@ venueFeatures: ["3 huge cinema screens", "Doulby Digital Surround EX audio syste
 tootsFeedImage: "mastodon-feed.jpg"
 tootsFeedTitle: "What's Up?"
 mastodonHashTag: "MenderCon2025"
-mastodonFeedApiUrl: "https://toot.legacycode.rocks/api/v1/timelines/tag/MenderCon2025"
-mastodonFeedUrl: "https://toot.legacycode.rocks/tags/MenderCon2025"
+mastodonServer: "https://toot.legacycode.rocks/"
+mastodonAccount: "@mendercon"
+mastodonFeedUrl: "tags/MenderCon2025"
+mastodonFeedApiUrl: "api/v1/timelines/tag/MenderCon2025"
+mastodonRefreshIntervalMilliSeconds: 15000
+
 
 # Partners Block
 organizersTitle: "Organizers"

--- a/_config.yml
+++ b/_config.yml
@@ -100,7 +100,7 @@ venueFeatures: ["3 huge cinema screens", "Doulby Digital Surround EX audio syste
 tootsFeedImage: "mastodon-feed.jpg"
 tootsFeedTitle: "What's Up?"
 mastodonHashTag: "MenderCon2025"
-mastodonFeedUrl: "https://toot.legacycode.rocks/api/v1/timelines/tag/MenderCon2025"
+mastodonFeedApiUrl: "https://toot.legacycode.rocks/api/v1/timelines/tag/MenderCon2025"
 
 # Partners Block
 organizersTitle: "Organizers"

--- a/_includes/mastodon-feed.html
+++ b/_includes/mastodon-feed.html
@@ -3,15 +3,76 @@
     <div class="overlay solid-overlay"></div>
     <div class="content-wrapper">
         <div class="col-md-8 col-md-offset-2">
-            <a href="{{site.mastodonServer}}/{{ site.mastodonAccount }}" target="_blank">
+            <a href="{{site.mastodonServer}}{{ site.mastodonAccount }}" target="_blank">
             <svg class="icon" viewBox="0 0 24 24">
                 <use xlink:href="{{ site.baseurl }}/img/sprites/sprites.svg#icon-mastodon"></use>
             </svg>
             </a>
-            <h3>{{ site.tootsFeedTitle }} <a href="{{ site.mastodonFeedUrl }}" target="_blank">#{{ site.mastodonHashTag }}</a>
+            <h3>{{ site.tootsFeedTitle }} <a href="{{site.mastodonServer}}{{ site.mastodonFeedUrl }}" target="_blank">#{{ site.mastodonHashTag }}</a>
             </h3>
             <div id="toots" class="toots"></div>
         </div>
     </div>
 </section>
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const mastodonFeedApiUrl = '{{ site.mastodonServer}}{{ site.mastodonFeedApiUrl }}';
+    const mastodonRefreshIntervalMilliSeconds = '{{ site.mastodonRefreshIntervalMilliSeconds }}';
+
+    if (typeof mastodonFeedApiUrl !== 'undefined' && mastodonFeedApiUrl) {
+        fetch(mastodonFeedApiUrl)
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                return response.json();
+            })
+            .then(data => {
+                const tootsContainer = document.getElementById('toots');
+                data.forEach(gist => {
+                    const tootDate = new Date(gist.created_at);
+                    const formattedTootDate = new Intl.DateTimeFormat('en-US', { 
+                        dateStyle: 'full', 
+                        timeStyle: 'long', 
+                        timeZone: 'America/New_York' 
+                    }).format(tootDate);
+
+                    const tootElement = document.createElement('div');
+                    tootElement.className = 'toot animated fadeInUp hidden';
+
+                    tootElement.innerHTML = 
+                        '<div class="toot-text">' + 
+                            gist.content + 
+                        '</div>' +
+                        '<p class="toot-meta">' +
+                            'by <a href="' + gist.account.url + '" target="_blank">@' + gist.account.display_name + '</a>' +
+                            ' posted <a href="' + gist.url + '" target="_blank">' + formattedTootDate + '</a>' +
+                        '</p>';
+
+                    tootsContainer.appendChild(tootElement);
+                });
+
+                animateToots();
+            })
+            .catch(error => console.error('Error fetching Mastodon feed:', error));
+
+        function animateToots() {
+            const toots = document.querySelectorAll('#toots .toot');
+            let i = 0;
+
+            if (toots.length === 0) return;
+
+            toots[0].classList.remove('hidden');
+
+            function changeToots() {
+                toots[i].classList.add('hidden');
+                i = (i + 1) % toots.length;
+                toots[i].classList.remove('hidden');
+            }
+
+            setInterval(changeToots, mastodonRefreshIntervalMilliSeconds);
+        }
+    }
+});
+</script>
 <!-- End Mastodon Feed Section -->

--- a/_includes/mastodon-feed.html
+++ b/_includes/mastodon-feed.html
@@ -8,7 +8,7 @@
                 <use xlink:href="{{ site.baseurl }}/img/sprites/sprites.svg#icon-mastodon"></use>
             </svg>
             </a>
-            <h3>{{ site.tootsFeedTitle }} <a href="{{ site.mastodonFeedApiUrl }}" target="_blank">#{{ site.mastodonHashTag }}</a>
+            <h3>{{ site.tootsFeedTitle }} <a href="{{ site.mastodonFeedUrl }}" target="_blank">#{{ site.mastodonHashTag }}</a>
             </h3>
             <div id="toots" class="toots"></div>
         </div>

--- a/_includes/mastodon-feed.html
+++ b/_includes/mastodon-feed.html
@@ -8,7 +8,7 @@
                 <use xlink:href="{{ site.baseurl }}/img/sprites/sprites.svg#icon-mastodon"></use>
             </svg>
             </a>
-            <h3>{{ site.tootsFeedTitle }} <a href="{{ site.mastodonFeedUrl }}" target="_blank">#{{ site.mastodonHashTag }}</a>
+            <h3>{{ site.tootsFeedTitle }} <a href="{{ site.mastodonFeedApiUrl }}" target="_blank">#{{ site.mastodonHashTag }}</a>
             </h3>
             <div id="toots" class="toots"></div>
         </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,7 @@ layout: compress
     <script>
         Waves.displayEffect();
         {% if page.permalink == '/' %}
-            var mastodonFeedUrl = '{{ site.mastodonFeedUrl }}';
+            var mastodonFeedApiUrl = '{{ site.mastodonFeedApiUrl }}';
             $(document).ready(function () {
                 $(function () {
                     if ($(window).width() > 767) {

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,7 +48,6 @@ layout: compress
     <script>
         Waves.displayEffect();
         {% if page.permalink == '/' %}
-            var mastodonFeedApiUrl = '{{ site.mastodonFeedApiUrl }}';
             $(document).ready(function () {
                 $(function () {
                     if ($(window).width() > 767) {

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -228,8 +228,8 @@
             location.hash = $(this).attr('id');
         });
 
-        if (typeof mastodonFeedUrl !== 'undefined') {
-            $.getJSON(mastodonFeedUrl, function(data) {
+        if (typeof mastodonFeedApiUrl !== 'undefined') {
+            $.getJSON(mastodonFeedApiUrl, function(data) {
                 $.each(data, function(i, gist) {
                     var tootDate = new Date(gist.created_at);
                     var formattedTootDate = new Intl.DateTimeFormat('en-US', { dateStyle: 'full', timeStyle: 'long', timeZone: 'America/New_York' }).format(tootDate);

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -227,39 +227,6 @@
         $('.slot').click(function() {
             location.hash = $(this).attr('id');
         });
-
-        if (typeof mastodonFeedApiUrl !== 'undefined') {
-            $.getJSON(mastodonFeedApiUrl, function(data) {
-                $.each(data, function(i, gist) {
-                    var tootDate = new Date(gist.created_at);
-                    var formattedTootDate = new Intl.DateTimeFormat('en-US', { dateStyle: 'full', timeStyle: 'long', timeZone: 'America/New_York' }).format(tootDate);
-                    var tootElement = 
-                        '<div class="toot animated fadeInUp hidden">' + 
-                            '<div class="toot-text">' + 
-                                gist.content + 
-                            '</div>' +
-                            '<p class="toot-meta">' +
-                                'by <a href="' + gist.account.url + '" target="_blank">@' + gist.account.display_name + '</a>' +
-                                ' posted <a href="' + gist.url + '" target="_blank">' + formattedTootDate + '</a>'
-                            '</p>' + 
-                        '</div>';
-                    $('#toots').append(tootElement);
-                });
-                animateToots();
-            });
-
-            function animateToots() {
-                var $toots = $('#toots').find('.toot'),
-                    i = 0;
-                $($toots.get(0)).removeClass('hidden');
-                function changeToots() {
-                    var next = (++i % $toots.length);
-                    $($toots.get(next - 1)).addClass('hidden');
-                    $($toots.get(next)).removeClass('hidden');
-                }
-                var interval = setInterval(changeToots, 5000);
-            }
-        }
     });
 
 })(jQuery);


### PR DESCRIPTION
Fixed the following issues:

- Hashtag link now redirects to the site instead of the API endpoint.
- Slowed the refresh rate from 5 seconds to 15.
- Moved the Mastodon JavaScript from the `scripts.js` into the `_includes/mastodon-feed.html`.

Fixes #65.
